### PR TITLE
adding 2 node hadr doc

### DIFF
--- a/ha.md
+++ b/ha.md
@@ -1,8 +1,8 @@
 ---
 
 copyright:
-  years: 2014, 2021, 2022
-lastupdated: "2023-08-17"
+  years: 2014, 2021, 2022, 2024
+lastupdated: "2024-09-13"
 
 keywords: HADR, Legacy Flex, legacy, Flex, high availability disaster recovery
 
@@ -30,6 +30,8 @@ The **blocknonlogged** parameter must always be set to **YES**.  Changing it to 
 {{site.data.keyword.Db2_on_Cloud_short}} high availability plans have excellent availability characteristics with a 99.99% SLA. 
 {: shortdesc}
 
+## Standard and Enterprise Plans
+
 <!--
 ## Standard and Enterprise plans
 {: #ha_v2_ha}
@@ -47,10 +49,28 @@ High availability disaster recovery (HADR) on {{site.data.keyword.Db2_on_Cloud_s
 
 - During failover events, you can expect between 10-20 seconds during which transactions are restricted. Your client can seamlessly fail over by using [automatic client reroute (ACR)](https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.admin.ha.doc/doc/r0023392.html){: external} along with appropriate retry logic for any failed transactions.
 
+## Performance Plan
+{: #ha_performance}
+
+High availability on {{site.data.keyword.Db2_on_Cloud_short}} performance plan is provided by leveraging the support of native Db2 HADR.
+
+- Each HA system consists of 2 nodes. 
+
+![Schematic view of the 2 nodes](images/legacy_ha_small.png "Schematic view of the 2 nodes"){: caption="Figure 1. Schematic view of the 2 nodes" caption-side="bottom"}
+
+- The primary node processes read and write transactions while the standby node provides read-only query capability. The standby node is replicated synchronously, which means each transaction is committed on at least 2 nodes before it is successful. This standby node is ready to take over write processing as well should any failure or maintenance event occur. 
+
+![Schematic view of primary node failover](images/legacy_ha_fail.png "Schematic view of primary node failover"){: caption="Figure 2. Schematic view of primary node failover" caption-side="bottom"}
+
+- During failover events, you can expect between 10-20 seconds during which transactions are restricted. Your client can seamlessly fail over by using [automatic client reroute (ACR)](https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.admin.ha.doc/doc/r0023392.html){: external} along with appropriate retry logic for any failed transactions.
+
+
+## General
+
 ### Managing HADR nodes
 {: #ha_v2_manage}
 
-For Enterprise and Standard HADR plans, the failover is managed for you by IBM. IBM monitors the health of your server, fail over and fail back as needed, including rolling updates and scaling to keep uptime as high as possible.
+For all HADR plans, the failover is managed for you by IBM. IBM monitors the health of your server, fail over and fail back as needed, including rolling updates and scaling to keep uptime as high as possible.
 
 <!--
 ## Legacy Flex plans


### PR DESCRIPTION
Thanks for taking the time to contribute to the IBM Cloud docs! After you open your pull request, a maintainer should review it soon.

We don't merge changes directly in this repository because content is not published from here. However, we'll incorporate any changes in our upstream repository so that they're reflected in the docs.

### Description

Db2 on cloud is moving to a 2 node hadr configuration for v3 architecture. The existing v2 3 node hadr configuration will still exist as is.

###  Any other comments?

I'm a developer for db2oc
---

### For reviewers (This section is only for IBMers)

You can't merge pull requests here.

- If you can incorporate these changes, copy them to your GitHub Enterprise repo. Leave a comment and close the pull request.
- If you can't accept the changes, leave information about why, and close the pull request.

If you don't have permission to close the request, ask for help in the IBM Cloud \#docs Slack channel.
